### PR TITLE
add prod deploy workflow and production tests

### DIFF
--- a/.github/workflows/netlify-deploy-prod.yml
+++ b/.github/workflows/netlify-deploy-prod.yml
@@ -1,17 +1,25 @@
-name: netlify
-on: [pull_request]
+name: netlify-prod
+# production deploys only happens on pushes to the master branch
+on:
+  push:
+    branches:
+      - master
+
 jobs:
-  netlify-preview:
+  netlify-prod:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Install dependencies
+
+      # first, let's test the site locally
+      - name: Cypress run
         uses: cypress-io/github-action@v1
         with:
-          # just perform install
-          runTests: false
-      - run: npx print-env GITHUB
+          start: npm run react:start
+          wait-on: 'http://localhost:3000'
+
+      # if the tests pass, let's build production site
       - name: Build site
         run: npm run build
         env:
@@ -20,7 +28,8 @@ jobs:
           # point API calls to "/api" that will later be redirected
           # to the remote API host
           REACT_APP_BASE_URL: '/api'
-      - name: Deploy to Netlify
+
+      - name: Deploy to Netlify prod
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -28,11 +37,6 @@ jobs:
         # and redirect its results into a JSON file
         run: |
           npm install netlify-cli
-          npx netlify deploy --dir build --json | tee deploy.json
-
-      - name: Run Cypress tests against draft deploy
-        run: node ./scripts/test-draft-site.js
-
-      # only runs read-only tests without stubbing
-      - name: Run prod tests against draft deploy
+          npx netlify deploy --prod --dir build --json | tee deploy.json
+      - name: Run Cypress tests against prod deploy
         run: node ./scripts/test-prod-site.js

--- a/cypress/integration/prod-spec.js
+++ b/cypress/integration/prod-spec.js
@@ -1,7 +1,11 @@
 // minimal number of tests that are safe to run
 // against the production deploy
 /// <reference types="cypress" />
-describe('prod tests', () => {
+import { isOn } from '@cypress/skip-test'
+
+const describeOrSkip = isOn('localhost') ? describe.skip : describe
+
+describeOrSkip('prod tests', () => {
 	it('has the current card', () => {
 		cy.visit('/')
 		cy.contains('Action Card').should('be.visible')

--- a/cypress/integration/prod-spec.js
+++ b/cypress/integration/prod-spec.js
@@ -1,0 +1,23 @@
+// minimal number of tests that are safe to run
+// against the production deploy
+/// <reference types="cypress" />
+describe('prod tests', () => {
+	it('has the current card', () => {
+		cy.visit('/')
+		cy.contains('Action Card').should('be.visible')
+		cy.contains('Track my actions!').should('be.visible')
+		cy.get('[data-cy=action-check-display]').should('have.length.gt', 3)
+	})
+
+	it('goes to past', () => {
+		cy.visit('/')
+		cy.contains('a[href="/past"]', 'Past').click()
+		cy.location('href').should('match', /\/past$/)
+		cy.get('[data-cy="close-open-card"]').should('have.length.gt', 2)
+	})
+
+	// TODO: enable after deploying the /past redirect
+	it.skip('has past cards', () => {
+		cy.visit('/past')
+	})
+})

--- a/scripts/test-prod-site.js
+++ b/scripts/test-prod-site.js
@@ -1,0 +1,27 @@
+// after Netlify deploys the production site
+// we save deploy results in `deploy.json` file (see Netlify GH workflow)
+// now we grab that file and run some Cypress tests against it
+const path = require('path')
+const filename = path.join(process.cwd(), 'deploy.json')
+console.log('loading Netlify deploy results from file %s', filename)
+const deploy = require(filename)
+console.log('will run Cypress tests against deployed url', deploy.deploy_url)
+
+const cypress = require('cypress')
+cypress
+	.run({
+		// only run tests safe against data modification
+		// and with minimal network stubbing
+		spec: 'cypress/integration/prod-spec.js',
+		config: {
+			baseUrl: deploy.deploy_url,
+		},
+	})
+	.then(results => {
+		if (results.failures) {
+			// really bad crash or cannot run tests
+			console.error(results.message)
+			process.exit(results.failures)
+		}
+		process.exit(results.totalFailed)
+	})


### PR DESCRIPTION
- closes #17 
- adds read-only tests that run against draft deploys and against prod deploys
- adds prod deploy on push from `master` branch and runs tests after that

This PR will start deploying automatically on merge to `master` and run sanity checks after deploy.